### PR TITLE
Issue 3 - rename `dryad stem exec`

### DIFF
--- a/docs/usage/cli/dryad-stem-run.md
+++ b/docs/usage/cli/dryad-stem-run.md
@@ -1,15 +1,15 @@
 ---
-title: dryad stem exec
+title: dryad stem run
 layout: default
 parent: CLI
 grand_parent: Usage
 ---
 
-# dryad stem exec
+# dryad stem run
 
 ```
-$ dryad stem exec --help
-dryad stem exec [--execPath=string] [--context=string] [--inherit] <path> [-- args]
+$ dryad stem run --help
+dryad stem run [--execPath=string] [--context=string] [--inherit] <path> [-- args]
 
 Description:
     execute the main for a stem
@@ -19,7 +19,7 @@ Arguments:
     -- args          args to pass to the stem, optional
 
 Options:
-        --execPath   path to the executable running `dryad stem exec`. used for path setting
+        --execPath   path to the executable running `dryad stem run`. used for path setting
         --context    name of the execution context. the HOME env var is set to the path for this context
         --inherit    pass all environment variables from the parent environment to the stem
 ```

--- a/dyd/roots/dryad/src/dyd/assets/core/root_build.go
+++ b/dyd/roots/dryad/src/dyd/assets/core/root_build.go
@@ -214,7 +214,7 @@ func rootBuild_stage5(rootStemPath string, stemBuildPath string, rootFingerprint
 	if err != nil {
 		return "", err
 	}
-	err = StemExec(StemExecRequest{
+	err = StemRun(StemRunRequest{
 		StemPath:   rootStemPath,
 		Env:        nil,
 		Args:       []string{stemBuildPath},

--- a/dyd/roots/dryad/src/dyd/assets/core/stem_run.go
+++ b/dyd/roots/dryad/src/dyd/assets/core/stem_run.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 )
 
-type StemExecRequest struct {
+type StemRunRequest struct {
 	StemPath   string
 	ExecPath   string
 	Context    string
@@ -17,7 +17,7 @@ type StemExecRequest struct {
 	JoinStdout bool
 }
 
-func stemExec_prepContext(request StemExecRequest) (string, error) {
+func stemRun_prepContext(request StemRunRequest) (string, error) {
 	context := request.Context
 	if context == "" {
 		context = "default"
@@ -37,7 +37,7 @@ func stemExec_prepContext(request StemExecRequest) (string, error) {
 	return contextPath, nil
 }
 
-func StemExec(request StemExecRequest) error {
+func StemRun(request StemRunRequest) error {
 	var execPath = request.ExecPath
 	var stemPath = request.StemPath
 	var env = request.Env
@@ -64,7 +64,7 @@ func StemExec(request StemExecRequest) error {
 		return err
 	}
 
-	contextPath, err := stemExec_prepContext(request)
+	contextPath, err := stemRun_prepContext(request)
 	if err != nil {
 		return err
 	}

--- a/dyd/roots/dryad/src/dyd/assets/main.go
+++ b/dyd/roots/dryad/src/dyd/assets/main.go
@@ -1245,7 +1245,7 @@ func _buildCLI() cli.App {
 					if includeSprouts(relPath) && !excludeSprouts(relPath) {
 						fmt.Println("[info] executing sprout at", path)
 
-						err := dryad.StemExec(dryad.StemExecRequest{
+						err := dryad.StemRun(dryad.StemRunRequest{
 							StemPath:   path,
 							Env:        env,
 							Args:       extras,
@@ -1350,7 +1350,7 @@ func _buildCLI() cli.App {
 		WithCommand(sproutsList).
 		WithCommand(sproutsPath)
 
-	var stemExec = cli.NewCommand("exec", "execute the main for a stem").
+	var stemRun = cli.NewCommand("run", "execute the main for a stem").
 		WithArg(cli.NewArg("path", "path to the stem base dir")).
 		WithOption(cli.NewOption("execPath", "path to the executable running `dryad stem exec`. used for path setting")).
 		WithOption(cli.NewOption("context", "name of the execution context. the HOME env var is set to the path for this context")).
@@ -1392,7 +1392,7 @@ func _buildCLI() cli.App {
 
 			path := args[0]
 			extras := args[1:]
-			err := dryad.StemExec(dryad.StemExecRequest{
+			err := dryad.StemRun(dryad.StemRunRequest{
 				ExecPath:   execPath,
 				StemPath:   path,
 				Env:        env,
@@ -1542,11 +1542,11 @@ func _buildCLI() cli.App {
 		})
 
 	var stem = cli.NewCommand("stem", "commands to work with dryad stems").
-		WithCommand(stemExec).
 		WithCommand(stemFingerprint).
 		WithCommand(stemFiles).
 		WithCommand(stemPack).
 		WithCommand(stemPath).
+		WithCommand(stemRun).
 		WithCommand(stemUnpack)
 
 	var stemsList = cli.NewCommand("list", "list all stems that are dependencies for the current root").


### PR DESCRIPTION
# Description

Fixes #3 

# Changes
- renaming `dryad stem exec` command to `dryad stem run`
- renaming `StemExec` to `StemRun`
- updating docs