### PR TITLE
Issue 24 - root init path

### DIFF
--- a/docs/usage/cli/dryad-root-init.md
+++ b/docs/usage/cli/dryad-root-init.md
@@ -9,11 +9,11 @@ grand_parent: Usage
 
 ```
 $ dryad root init --help
-dryad root init [path]
+dryad root init <path>
 
 Description:
-    create a new root directory structure in the current dir
+    create a new root at the target path
 
 Arguments:
-    path   the path to init the root at. defaults to current directory, optional
+    path   the path to init the new root at
 ```

--- a/dyd/roots/dryad/src/dyd/assets/core/root_init.go
+++ b/dyd/roots/dryad/src/dyd/assets/core/root_init.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -9,6 +10,13 @@ func RootInit(path string) error {
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return err
+	}
+
+	pathExists, err := fileExists(path)
+	if err != nil {
+		return err
+	} else if pathExists {
+		return fmt.Errorf("error: init destination %s already exists", path)
 	}
 
 	var basePath string = filepath.Join(path, "dyd")
@@ -20,7 +28,6 @@ func RootInit(path string) error {
 	if _, err := os.Create(flagPath); err != nil {
 		return err
 	}
-
 
 	var assetsPath string = filepath.Join(basePath, "assets")
 	if err := os.MkdirAll(assetsPath, os.ModePerm); err != nil {

--- a/dyd/roots/dryad/src/dyd/assets/main.go
+++ b/dyd/roots/dryad/src/dyd/assets/main.go
@@ -312,16 +312,12 @@ func _buildCLI() cli.App {
 			return 0
 		})
 
-	var rootInit = cli.NewCommand("init", "create a new root directory structure in the current dir").
-		WithArg(cli.NewArg("path", "the path to init the root at. defaults to current directory").AsOptional()).
+	var rootInit = cli.NewCommand("init", "create a new root at the target path").
+		WithArg(cli.NewArg("path", "the path to init the new root at")).
 		WithAction(func(req cli.ActionRequest) int {
 			var args = req.Args
 
-			var path string = ""
-
-			if len(args) > 0 {
-				path = args[0]
-			}
+			var path string = args[0]
 
 			err := dryad.RootInit(path)
 


### PR DESCRIPTION
# Description

Fixes #24 

# Changes

- updating RootInit to check to make sure the target doesn't exist
- updating `dryad root init` to make the path a required argument
- updating the docs for `dryad root init`