### PR TITLE
Issue 23 restrict root copy

### DIFF
--- a/dyd/roots/dryad/src/dyd/assets/core/file_is_descendant.go
+++ b/dyd/roots/dryad/src/dyd/assets/core/file_is_descendant.go
@@ -1,0 +1,21 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func fileIsDescendant(path string, parent string) (bool, error) {
+	up := ".." + string(os.PathSeparator)
+
+	// path-comparisons using filepath.Abs don't work reliably according to docs (no unique representation).
+	rel, err := filepath.Rel(parent, path)
+	if err != nil {
+		return false, err
+	}
+	if !strings.HasPrefix(rel, up) && rel != ".." && rel != "." {
+		return true, nil
+	}
+	return false, nil
+}

--- a/dyd/roots/dryad/src/dyd/assets/core/root_copy.go
+++ b/dyd/roots/dryad/src/dyd/assets/core/root_copy.go
@@ -68,6 +68,24 @@ func RootCopy(sourcePath string, destPath string) error {
 		return err
 	}
 
+	// temporary workaround until RootsPath is more correct
+	gardenPath, err := GardenPath(sourcePath)
+	if err != nil {
+		return err
+	}
+	rootsPath, err := RootsPath(gardenPath)
+	if err != nil {
+		return err
+	}
+
+	isWithinRoots, err := fileIsDescendant(destPath, rootsPath)
+	if err != nil {
+		return err
+	}
+	if !isWithinRoots {
+		return fmt.Errorf("destination path %s is outside of roots", destPath)
+	}
+
 	// gardenPath, err := GardenPath(sourcePath)
 	// if err != nil {
 	// 	return err


### PR DESCRIPTION
# Description

Fixes #22, #23.

This PR adds a check to `RootCopy` to make sure the destination for the root is still within the correct subdirectory.

# Changes

- fixing RootCopy to stay within garden bounds
- adding fileIsDescendant utlity function
 