### PR TITLE
Issue 28 - heap protection

### DIFF
--- a/dyd/roots/dryad/publish/release_artifacts/dyd/main
+++ b/dyd/roots/dryad/publish/release_artifacts/dyd/main
@@ -15,26 +15,31 @@ TEMP_DIR=$(mktemp -d)
 
 VERSION="$(cat $SRC_DIR/dyd/stems/darwin-arm64/dyd/traits/version)"
 cp -L $SRC_DIR/dyd/stems/darwin-arm64/dyd/main $TEMP_DIR/dryad
+chmod +755 $TEMP_DIR/dryad
 tar -chzvf $DEST_DIR/dyd/assets/dryad-$VERSION-darwin-arm64.tar.gz -C $TEMP_DIR ./dryad
 rm -rf $TEMP_DIR/dryad
 
 VERSION="$(cat $SRC_DIR/dyd/stems/darwin-amd64/dyd/traits/version)"
 cp -L $SRC_DIR/dyd/stems/darwin-amd64/dyd/main $TEMP_DIR/dryad
+chmod +755 $TEMP_DIR/dryad
 tar -chzvf $DEST_DIR/dyd/assets/dryad-$VERSION-darwin-amd64.tar.gz -C $TEMP_DIR ./dryad
 rm -rf $TEMP_DIR/dryad
 
 VERSION="$(cat $SRC_DIR/dyd/stems/linux-arm64/dyd/traits/version)"
 cp -L $SRC_DIR/dyd/stems/linux-arm64/dyd/main $TEMP_DIR/dryad
+chmod +755 $TEMP_DIR/dryad
 tar -chzvf $DEST_DIR/dyd/assets/dryad-$VERSION-linux-arm64.tar.gz -C $TEMP_DIR ./dryad
 rm -rf $TEMP_DIR/dryad
 
 VERSION="$(cat $SRC_DIR/dyd/stems/linux-amd64/dyd/traits/version)"
 cp -L $SRC_DIR/dyd/stems/linux-amd64/dyd/main $TEMP_DIR/dryad
+chmod +755 $TEMP_DIR/dryad
 tar -chzvf $DEST_DIR/dyd/assets/dryad-$VERSION-linux-amd64.tar.gz -C $TEMP_DIR ./dryad
 rm -rf $TEMP_DIR/dryad
 
 VERSION="$(cat $SRC_DIR/dyd/stems/src/dyd/traits/version)"
 cp -LR $SRC_DIR/dyd/stems/src/dyd/assets $TEMP_DIR/dryad
+chmod -R +755 $TEMP_DIR/dryad
 tar -chzvf $DEST_DIR/dyd/assets/dryad-$VERSION-src.tar.gz -C $TEMP_DIR ./dryad
 
 

--- a/dyd/roots/dryad/src/dyd/assets/core/heap_add_file.go
+++ b/dyd/roots/dryad/src/dyd/assets/core/heap_add_file.go
@@ -45,7 +45,8 @@ func HeapAddFile(heapPath string, filePath string) (string, error) {
 			return "", err
 		}
 
-		err = destFile.Chmod(os.ModePerm)
+		// heap files should be set to R-X--X--X
+		err = destFile.Chmod(0o511)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
# Description

Fixes #28.

To prevent accidental editing of resources in the heap, I restricted the permissions on heap resources, setting them as read-only on add.

# Changelog

- setting heap files to read-only on add
- setting heap secrets to read-only on add
- setting heap stems to read-only on add