### PR TITLE
Issue 42 stem files crash

### DIFF
--- a/docs/usage/cli/dryad-stem-files.md
+++ b/docs/usage/cli/dryad-stem-files.md
@@ -9,10 +9,13 @@ grand_parent: Usage
 
 ```
 $ dryad stem files --help
-dryad stem files [--exclude=string]
+dryad stem files [--exclude=string] [path]
 
 Description:
     list the files in a stem
+
+Arguments:
+    path            path to the stem base dir, optional
 
 Options:
         --exclude   a regular expression to exclude files from the list. the regexp matches against the file path relative to the stem base directory

--- a/dyd/roots/dryad/src/dyd/assets/main.go
+++ b/dyd/roots/dryad/src/dyd/assets/main.go
@@ -1551,8 +1551,6 @@ func _buildCLI() cli.App {
 			var err error
 			var matchExclude *regexp.Regexp
 
-			fmt.Println("stemFiles options", options, options["exclude"])
-
 			if options["exclude"] != nil && options["exclude"] != "" {
 				matchExclude, err = regexp.Compile(options["exclude"].(string))
 				if err != nil {


### PR DESCRIPTION
# Description

Fixes #42, #43 

This PR fixes a bug in the CLI interface for `dryad stem files`.  It also adds the path argument to `dryad stem files` (which should have been there in the first place).

