### PR TITLE
Issue 95 - scope oneline support

### DIFF
--- a/dyd/roots/source/dryad/dyd/assets/cli/scope-active.go
+++ b/dyd/roots/source/dryad/dyd/assets/cli/scope-active.go
@@ -10,7 +10,15 @@ import (
 
 var scopeActiveCommand = func() clib.Command {
 	command := clib.NewCommand("active", "return the name of the active scope, if set. alias for `dryad scopes default get`").
+		WithOption(clib.NewOption("oneline", "enable/disable printing one-line scope descriptions").WithType(clib.OptionTypeBool)).
 		WithAction(func(req clib.ActionRequest) int {
+			var opts = req.Opts
+
+			var oneline bool = true
+
+			if opts["oneline"] != nil {
+				oneline = opts["oneline"].(bool)
+			}
 
 			var path, err = os.Getwd()
 			if err != nil {
@@ -22,9 +30,20 @@ var scopeActiveCommand = func() clib.Command {
 				log.Fatal(err)
 			}
 
-			if scopeName != "" {
-				fmt.Println(scopeName)
+			if scopeName == "" {
+				return 0
 			}
+
+			var scopeOneline string = ""
+			if oneline {
+				scopeOneline, _ = dryad.ScopeOnelineGet(path, scopeName)
+			}
+
+			if scopeOneline != "" {
+				scopeName = scopeName + " - " + scopeOneline
+			}
+
+			fmt.Println(scopeName)
 
 			return 0
 		})

--- a/dyd/roots/source/dryad/dyd/assets/cli/scopes-list.go
+++ b/dyd/roots/source/dryad/dyd/assets/cli/scopes-list.go
@@ -12,11 +12,18 @@ import (
 
 var scopesListCommand = func() clib.Command {
 	command := clib.NewCommand("list", "list all scopes in the current garden").
+		WithOption(clib.NewOption("oneline", "enable/disable printing one-line scope descriptions").WithType(clib.OptionTypeBool)).
 		WithAction(func(req clib.ActionRequest) int {
 			var args = req.Args
+			var opts = req.Opts
 
 			var path string = ""
 			var err error
+			var oneline bool = true
+
+			if opts["oneline"] != nil {
+				oneline = opts["oneline"].(bool)
+			}
 
 			if len(args) > 0 {
 				path = args[0]
@@ -25,7 +32,18 @@ var scopesListCommand = func() clib.Command {
 			var scopes []string
 
 			err = dryad.ScopesWalk(path, func(path string, info fs.FileInfo) error {
-				scopes = append(scopes, filepath.Base(path))
+				scope := filepath.Base(path)
+
+				// fetch the oneline if enabled
+				if oneline {
+					scopeOneline, _ := dryad.ScopeOnelineGet(path, scope)
+					if scopeOneline != "" {
+						scope = scope + " - " + scopeOneline
+					}
+				}
+
+				scopes = append(scopes, scope)
+
 				return nil
 			})
 			if err != nil {

--- a/dyd/roots/source/dryad/dyd/assets/core/scope_oneline_get.go
+++ b/dyd/roots/source/dryad/dyd/assets/core/scope_oneline_get.go
@@ -1,0 +1,5 @@
+package core
+
+func ScopeOnelineGet(basePath string, scope string) (string, error) {
+	return ScopeSettingGet(basePath, scope, ".oneline")
+}

--- a/dyd/roots/source/dryad/dyd/assets/core/scope_oneline_set.go
+++ b/dyd/roots/source/dryad/dyd/assets/core/scope_oneline_set.go
@@ -1,0 +1,5 @@
+package core
+
+func ScopeOnelineSet(basePath string, scope string, value string) error {
+	return ScopeSettingSet(basePath, scope, ".oneline", value)
+}

--- a/dyd/shed/scopes/devshell/.oneline
+++ b/dyd/shed/scopes/devshell/.oneline
@@ -1,0 +1,1 @@
+scope for building a shell environment for developing dryad

--- a/dyd/shed/scopes/release/.oneline
+++ b/dyd/shed/scopes/release/.oneline
@@ -1,0 +1,1 @@
+scope for building release builds

--- a/dyd/shed/scopes/test/.oneline
+++ b/dyd/shed/scopes/test/.oneline
@@ -1,0 +1,1 @@
+scope for test cases


### PR DESCRIPTION
# Description

Fixes #95 

# Changes
- adding scope oneline support to the core
- adding oneline printing to `dryad scopes list` and `dryad scope active`
- adding onelines to the existing scopes