### PR TITLE
Issue 167 - `dryad root develop` should be scoped command

### DIFF
--- a/dyd/roots/source/docs/dyd/assets/src/03-usage/03-cli-reference/dryad-root-develop.md
+++ b/dyd/roots/source/docs/dyd/assets/src/03-usage/03-cli-reference/dryad-root-develop.md
@@ -2,7 +2,7 @@
 
 ```
 $ dryad root develop --help
-dryad root develop [--editor=string] [--arg=multi-string] [--inherit=boolean] [--log-level=string] [--log-format=string] [--help] [path]
+dryad root develop [--editor=string] [--arg=multi-string] [--inherit=boolean] [--scope=string] [--log-level=string] [--log-format=string] [--help] [path]
 
 Description:
     create a temporary development environment for a root
@@ -14,6 +14,7 @@ Options:
         --editor       choose the editor to run in the root development environment
         --arg          argument to pass to the editor
         --inherit      inherit env variables from the host environment
+        --scope        set the scope for the command
         --log-level    set the logging level. can be one of 'panic', 'fatal', 'error', 'warn', 'info', 'debug', or 'trace'.  defaults to 'info'
         --log-format   set the logging format. can be one of 'console' or 'json'.  defaults to 'console'
         --help         display help text for this command

--- a/dyd/roots/source/docs/dyd/assets/src/03-usage/03-cli-reference/dryad.md
+++ b/dyd/roots/source/docs/dyd/assets/src/03-usage/03-cli-reference/dryad.md
@@ -5,7 +5,7 @@ $ dryad --help
 dryad
 
 Description:
-    dryad package manager 0.9.7,-X=main.Fingerprint=blake2b-f0e0145ea4097e81221ed47e3b2d0604,-s,-w
+    dryad package manager 0.10.0,-X=main.Fingerprint=blake2b-2e6010be624982f461ad4afb727eb1bb,-s,-w
 
 Sub-commands:
     dryad garden    commands to work with a dryad garden

--- a/dyd/roots/source/dryad/dyd/assets/cli/root-develop.go
+++ b/dyd/roots/source/dryad/dyd/assets/cli/root-develop.go
@@ -76,6 +76,7 @@ var rootDevelopCommand = func() clib.Command {
 			return 0
 		})
 
+	command = ScopedCommand(command)
 	command = LoggingCommand(command)
 	command = HelpCommand(command)
 


### PR DESCRIPTION
# Description
Fixes #167 

# Changes
- adding scope wrapper to root develop command
- updating docs