### PR TITLE
228 - `dryad root ancestors` should error on non-root paths

### DIFF
--- a/dyd/roots/source/dryad/dyd/assets/cli/root-ancestors.go
+++ b/dyd/roots/source/dryad/dyd/assets/cli/root-ancestors.go
@@ -52,6 +52,12 @@ var rootAncestorsCommand = func() clib.Command {
 				return 1
 			}
 
+			rootPath, err = dryad.RootPath(rootPath)
+			if err != nil {
+				zlog.Fatal().Err(err).Msg("error while resolving root path")
+				return 1
+			}
+
 			graph, err := dryad.RootsGraph(gardenPath, relative)
 			if err != nil {
 				zlog.Fatal().Err(err).Msg("error while building graph")


### PR DESCRIPTION
Fixes #228 