### PR TITLE
229 - `dryad root descendants` should error on non-root paths

### DIFF
--- a/dyd/roots/source/dryad/dyd/assets/cli/root-descendants.go
+++ b/dyd/roots/source/dryad/dyd/assets/cli/root-descendants.go
@@ -51,6 +51,12 @@ var rootDescendantsCommand = func() clib.Command {
 				return 1
 			}
 
+			rootPath, err = dryad.RootPath(rootPath)
+			if err != nil {
+				zlog.Fatal().Err(err).Msg("error while resolving root path")
+				return 1
+			}
+
 			graph, err := dryad.RootsGraph(gardenPath, relative)
 			if err != nil {
 				zlog.Fatal().Err(err).Msg("error while building graph")


### PR DESCRIPTION
Fixes #229 