### PR TITLE
262 - concurrency issue with adding stems to heap

### DIFF
--- a/dyd/roots/components/dryad-cli/source/dyd/assets/core/root_build.go
+++ b/dyd/roots/components/dryad-cli/source/dyd/assets/core/root_build.go
@@ -249,8 +249,8 @@ func rootBuild(ctx *task.ExecutionContext, req rootBuildRequest) (error, string)
 
 var memoRootBuild = task.Memoize(
 	rootBuild,
-	func (req rootBuildRequest) any {
-		return struct {
+	func (ctx * task.ExecutionContext, req rootBuildRequest) (error, any) {
+		var res = struct {
 			Group string
 			GardenPath string
 			RootPath string
@@ -259,6 +259,7 @@ var memoRootBuild = task.Memoize(
 			GardenPath: req.Root.Roots.Garden.BasePath,
 			RootPath: req.Root.BasePath,
 		}
+		return nil, res
 	},
 )
 

--- a/dyd/roots/components/dryad-cli/source/dyd/assets/task/memoize.go
+++ b/dyd/roots/components/dryad-cli/source/dyd/assets/task/memoize.go
@@ -36,10 +36,17 @@ func onceWrapper[A any, B any](
 
 func Memoize[A any, B any](
 	task Task[A, B],
-	keyFunc func (req A) any,
+	keyFunc Task[A, any],
 ) Task[A, B] {
 	return func (ctx *ExecutionContext, req A) (error, B) {
-		var key = keyFunc(req)
+		var err error
+		var key any
+		var res B
+		
+		err, key = keyFunc(ctx, req)
+		if err != nil {
+			return err, res
+		}
 
 		var cachedTask any 
 		var hasCachedTask bool
@@ -58,8 +65,6 @@ func Memoize[A any, B any](
 			// 	Msg("memogroup updated")
 		}
 
-		var err error
-		var res B
 		err, res = cachedTask.(Task[A, B])(ctx, req)
 
 		// var jsonReq, _ = json.Marshal(req)

--- a/dyd/roots/components/dryad-cli/tests/root-copy-02/dyd/assets/commands/default
+++ b/dyd/roots/components/dryad-cli/tests/root-copy-02/dyd/assets/commands/default
@@ -39,6 +39,8 @@ _prepare() {
 
 _test() {
 	cd "$TEMP_DIR";
+	# NOTE: this root is copied several times, to attempt to trigger
+	# any pathological concurrency issues in the build
 	dryad root copy dyd/roots/root-01 dyd/roots/root-02 --log-level="$DYD_LOG_LEVEL" 1>&2;
 	dryad root copy dyd/roots/root-01 dyd/roots/root-03 --log-level="$DYD_LOG_LEVEL" 1>&2;
 	dryad root copy dyd/roots/root-01 dyd/roots/root-04 --log-level="$DYD_LOG_LEVEL" 1>&2;

--- a/dyd/roots/components/dryad-cli/tests/root-copy-02/dyd/assets/commands/default
+++ b/dyd/roots/components/dryad-cli/tests/root-copy-02/dyd/assets/commands/default
@@ -40,9 +40,9 @@ _prepare() {
 _test() {
 	cd "$TEMP_DIR";
 	dryad root copy dyd/roots/root-01 dyd/roots/root-02 --log-level="$DYD_LOG_LEVEL" 1>&2;
-	# TODO: this is a temporary fix to the test case,
-	# until HeapAddStem is made concurrent-safe
-	touch dyd/roots/root-02/dyd/assets/test-file-02
+	dryad root copy dyd/roots/root-01 dyd/roots/root-03 --log-level="$DYD_LOG_LEVEL" 1>&2;
+	dryad root copy dyd/roots/root-01 dyd/roots/root-04 --log-level="$DYD_LOG_LEVEL" 1>&2;
+	dryad root copy dyd/roots/root-01 dyd/roots/root-05 --log-level="$DYD_LOG_LEVEL" 1>&2;
 	dryad roots build --log-level="$DYD_LOG_LEVEL" 1>&2;
 }
 

--- a/dyd/roots/components/dryad-cli/tests/root-copy-03/dyd/assets/commands/default
+++ b/dyd/roots/components/dryad-cli/tests/root-copy-03/dyd/assets/commands/default
@@ -39,10 +39,12 @@ _prepare() {
 
 _test() {
 	cd "$TEMP_DIR/dyd/roots";
+	# NOTE: this root is copied several times, to attempt to trigger
+	# any pathological concurrency issues in the build
 	dryad root copy ./root-01 ./root-02 --log-level="$DYD_LOG_LEVEL" 1>&2;
-	# TODO: this is a temporary fix to the test case,
-	# until HeapAddStem is made concurrent-safe
-	touch ./root-02/dyd/assets/test-file-02
+	dryad root copy ./root-01 ./root-03 --log-level="$DYD_LOG_LEVEL" 1>&2;
+	dryad root copy ./root-01 ./root-04 --log-level="$DYD_LOG_LEVEL" 1>&2;
+	dryad root copy ./root-01 ./root-05 --log-level="$DYD_LOG_LEVEL" 1>&2;
 	dryad roots build --log-level="$DYD_LOG_LEVEL" 1>&2;
 }
 


### PR DESCRIPTION
This PR is not a permanent fix, as it doesn't fix concurrent operations on the heap, but uses memoization to prevent them. Further improvements will be implemented, but this operation should be memoized regardless.